### PR TITLE
feat: add inputFormatters to M3ETextField

### DIFF
--- a/lib/components/text_fields/m3e_text_fields.dart
+++ b/lib/components/text_fields/m3e_text_fields.dart
@@ -25,6 +25,7 @@ class M3ETextField extends StatefulWidget {
     this.enabled = true,
     this.keyboardType,
     this.textInputAction,
+    this.inputFormatters,
     this.onChanged,
     this.onSubmitted,
     this.onTapOutside,
@@ -68,6 +69,9 @@ class M3ETextField extends StatefulWidget {
 
   /// textInputAction.
   final TextInputAction? textInputAction;
+
+  /// inputFormatters.
+  final List<TextInputFormatter>? inputFormatters;
 
   /// onChanged.
   final ValueChanged<String>? onChanged;
@@ -261,6 +265,7 @@ class _M3ETextFieldState extends State<M3ETextField> {
       maxLines: widget.maxLines,
       keyboardType: widget.keyboardType,
       textInputAction: widget.textInputAction,
+      inputFormatters: widget.inputFormatters,
       onSubmitted: widget.onSubmitted,
       onTapOutside:
           widget.onTapOutside ?? M3EFocus.tapOutsideHandler(_focusNode),


### PR DESCRIPTION
## What
Adds an `inputFormatters` parameter to `M3ETextField` and forwards it to the underlying `EditableText`, matching the existing `keyboardType`/`textInputAction` passthrough.

## Why
There's currently no supported way to restrict input (e.g. `FilteringTextInputFormatter`, `LengthLimitingTextInputFormatter`). `onChanged` isn't suitable for sanitizing text as it mutates the controller, re-triggering itself and causing cursor jumps.

## Changes
- `lib/components/text_fields/m3e_text_fields.dart`: add `List<TextInputFormatter>? inputFormatters` param and forward to `EditableText`