### PR TITLE
fix: M3ETextField keyboard toggling when tapping label/padding

### DIFF
--- a/lib/components/text_fields/m3e_text_fields.dart
+++ b/lib/components/text_fields/m3e_text_fields.dart
@@ -154,28 +154,33 @@ class _M3ETextFieldState extends State<M3ETextField> {
     );
     final outlined = widget.variant == M3ETextFieldVariant.outlined;
 
-    return GestureDetector(
-      onTap: () => _focusNode.requestFocus(),
-      behavior: HitTestBehavior.opaque,
-      child: AnimatedContainer(
-        duration: M3EMotion.short3,
-        curve: M3EMotion.standard,
-        padding: textFieldTheme.horizontalPadding,
-        constraints: BoxConstraints(minHeight: textFieldTheme.minHeight),
-        decoration: textFieldTheme.backgroundDecoration(
-          scheme,
-          outlined: outlined,
+    return TapRegion(
+      enabled: widget.enabled,
+      onTapOutside:
+          widget.onTapOutside ?? M3EFocus.tapOutsideHandler(_focusNode),
+      child: GestureDetector(
+        onTap: () => _focusNode.requestFocus(),
+        behavior: HitTestBehavior.opaque,
+        child: AnimatedContainer(
+          duration: M3EMotion.short3,
+          curve: M3EMotion.standard,
+          padding: textFieldTheme.horizontalPadding,
+          constraints: BoxConstraints(minHeight: textFieldTheme.minHeight),
+          decoration: textFieldTheme.backgroundDecoration(
+            scheme,
+            outlined: outlined,
+          ),
+          // Painted over the container so the focused stroke does not inset
+          // layout and grow the field.
+          foregroundDecoration: textFieldTheme.borderDecoration(
+            scheme,
+            accent: accent,
+            outlined: outlined,
+            focused: _focused,
+            hasError: widget.hasError,
+          ),
+          child: Row(children: _buildRowChildren(theme, scheme, accent)),
         ),
-        // Painted over the container so the focused stroke does not inset
-        // layout and grow the field.
-        foregroundDecoration: textFieldTheme.borderDecoration(
-          scheme,
-          accent: accent,
-          outlined: outlined,
-          focused: _focused,
-          hasError: widget.hasError,
-        ),
-        child: Row(children: _buildRowChildren(theme, scheme, accent)),
       ),
     );
   }
@@ -306,8 +311,7 @@ class _M3ETextFieldState extends State<M3ETextField> {
       textInputAction: widget.textInputAction,
       inputFormatters: widget.inputFormatters,
       onSubmitted: widget.onSubmitted,
-      onTapOutside:
-          widget.onTapOutside ?? M3EFocus.tapOutsideHandler(_focusNode),
+      onTapOutside: (_) {},
       style: inputStyle,
       cursorColor: accent,
       backgroundCursorColor: scheme.outlineVariant,


### PR DESCRIPTION
**Problem**
Tapping a focused `M3ETextField` on any area outside the editable text region (the floating label, container padding) dismisses and immediately re-shows the on-screen keyboard. Each subsequent tap cycles focus off→on, so the keyboard flickers/toggles.

### Before

| Outline variant | Filled variant |
| :-: | :-: |
| <img width="380" alt="before outline" src="https://github.com/user-attachments/assets/6c4944f4-c3c4-4c4b-9930-9c57418942e4" /> | <img width="380" alt="before filled" src="https://github.com/user-attachments/assets/9f53f134-e050-41b3-ae7a-7fe74a878a7f" /> |

**Root cause**
`_M3ETextFieldState` wraps the whole field in a `GestureDetector` that calls `_focusNode.requestFocus()` (`m3e_text_fields.dart`), while the inner `EditableText` sets `onTapOutside` to `M3EFocus.tapOutsideHandler`, which unfocuses. A single tap on the label/padding lands outside the `EditableText`'s region, so the same gesture triggers both: pointer-down unfocuses (keyboard hides) and pointer-up re-requests focus (keyboard shows).

**Fix**
- Wrap the field in a `TapRegion` and move the outside-tap handling there (`onTapOutside: widget.onTapOutside ?? M3EFocus.tapOutsideHandler(_focusNode)`), so unfocus only fires when tapping genuinely outside the field.
- Set the inner `EditableText.onTapOutside` to a no-op so taps inside the field never unfocus.
Taps anywhere on the field now just request focus (a no-op when already focused), while background taps still dismiss the keyboard and focus still moves between fields. Works identically for `filled` and `outlined` variants.

### After

| Outline variant | Filled variant |
| :-: | :-: |
| <img width="380" alt="after outline" src="https://github.com/user-attachments/assets/2b5f4f03-65f1-4d7e-92b2-97593f62589b" /> | <img width="380" alt="after filled" src="https://github.com/user-attachments/assets/3f23b158-2a0d-485b-a5ed-838f90f0f4c4" /> |
