### PR TITLE
fix: search view suggestions obscured by system navigation bar

### DIFF
--- a/lib/components/search/components/m3e_search_view_build.dart
+++ b/lib/components/search/components/m3e_search_view_build.dart
@@ -136,7 +136,10 @@ extension _M3ESearchViewContentBuild on _M3ESearchViewContentState {
                   removeTop: true,
                   child: ListView(
                     padding: EdgeInsets.only(
-                      bottom: MediaQuery.viewInsetsOf(context).bottom,
+                      bottom: math.max(
+                        MediaQuery.viewPaddingOf(context).bottom,
+                        MediaQuery.viewInsetsOf(context).bottom,
+                      ),
                     ),
                     shrinkWrap: styles.shrinkWrap,
                     children: _suggestions.toList(),


### PR DESCRIPTION
## Problem

When 3-button navigation is enabled on Android, the last suggestion(s) in the
`M3ESearchAnchor` view are partially or fully hidden behind the system
navigation bar, even when scrolled to the bottom of the list.

## Root cause

The default suggestions `ListView` in `M3ESearchViewContent` only applied the
keyboard inset as bottom padding (`MediaQuery.viewInsetsOf(context).bottom`)
and ignored the safe-area inset entirely
(`MediaQuery.viewPaddingOf(context).bottom`). With edge-to-edge rendering, the
list viewport extends under the translucent navigation bar, so the final rows
are covered when the keyboard is closed.

Additionally, app-side workarounds (e.g. appending a trailing `SizedBox`
spacer in `suggestionsBuilder`) are unreliable because suggestions are built
once per query change and cached. While the IME is open, Android reports
`viewPadding.bottom = 0` (the inset moves into `viewInsets`), so a spacer
computed at build time collapses once suggestions are regenerated with the
keyboard up.

## Fix

Compute the list's bottom padding live on every build as:

```dart
math.max(
  MediaQuery.viewPaddingOf(context).bottom,
  MediaQuery.viewInsetsOf(context).bottom,
),
```

| Before | After |
| :-: | :-: |
| <img width="1080" height="214" alt="Screenshot_20260823-050229~2" src="https://github.com/user-attachments/assets/b7241b4a-7464-4380-a574-e348da6b3704" /> | <img width="1080" height="329" alt="Screenshot_20260823-050554" src="https://github.com/user-attachments/assets/2806f90e-9eef-48f9-9ce3-83783d418740" /> |
