### PR TITLE
fix(exports): export missing enums and models across components

### DIFF
--- a/lib/components/buttons/m3e_buttons.dart
+++ b/lib/components/buttons/m3e_buttons.dart
@@ -13,6 +13,7 @@ import 'components/m3e_radius_and_padding_motion.dart';
 import 'enums/m3e_button_enums.dart';
 import 'utils/m3e_button_gradient_layer.dart';
 
+export 'enums/m3e_button_enums.dart';
 export 'models/m3e_button_measurements.dart';
 export 'res/m3e_button_constants.dart';
 export 'styles/m3e_button_decoration.dart';

--- a/lib/components/floating_action_buttons/m3e_floating_action_buttons.dart
+++ b/lib/components/floating_action_buttons/m3e_floating_action_buttons.dart
@@ -6,6 +6,7 @@ import 'enums/m3e_fab.dart';
 import 'styles/m3e_fab_decoration.dart';
 import 'styles/m3e_fab_theme.dart';
 
+export 'enums/m3e_fab.dart';
 export 'styles/m3e_fab_decoration.dart';
 
 /// A Material 3 Expressive floating action button.

--- a/lib/components/navigation_bar/m3e_navigation_bar.dart
+++ b/lib/components/navigation_bar/m3e_navigation_bar.dart
@@ -9,6 +9,11 @@ import 'models/m3e_nav_metrics.dart';
 import 'models/m3e_navigation_bar_destination.dart';
 import 'styles/m3e_navigation_bar_theme.dart';
 
+export 'enums/m3e_nav_bar_enums.dart';
+export 'models/m3e_nav_metrics.dart';
+export 'models/m3e_navigation_bar_destination.dart';
+export 'styles/m3e_navigation_bar_theme.dart';
+
 /// A Material 3 Expressive navigation bar.
 ///
 /// Pill selection uses a lead/trail spring indicator that stretches between

--- a/lib/components/navigation_rail/m3e_navigation_rail.dart
+++ b/lib/components/navigation_rail/m3e_navigation_rail.dart
@@ -14,6 +14,12 @@ import 'models/m3e_navigation_rail_section.dart';
 import 'res/m3e_navigation_rail_layout.dart';
 import 'styles/m3e_navigation_rail_theme.dart';
 
+export 'enums/m3e_navigation_rail_enums.dart';
+export 'models/m3e_navigation_rail_destination.dart';
+export 'models/m3e_navigation_rail_fab_slot.dart';
+export 'models/m3e_navigation_rail_section.dart';
+export 'styles/m3e_navigation_rail_theme.dart';
+
 part 'components/m3e_navigation_rail_children_mixin.dart';
 
 /// Material 3 Expressive Navigation Rail — single widget that animates between states.

--- a/lib/components/split_buttons/m3e_split_buttons.dart
+++ b/lib/components/split_buttons/m3e_split_buttons.dart
@@ -22,6 +22,9 @@ import 'styles/m3e_split_button_popup_decoration.dart';
 import 'styles/m3e_split_button_theme.dart';
 
 export '../menus/models/m3e_menu_node.dart';
+export 'enums/m3e_split_button_menu_style.dart';
+export 'enums/m3e_split_button_selection_mode.dart';
+export 'enums/m3e_split_button_trailing_alignment.dart';
 export 'models/m3e_split_button_item.dart';
 export 'styles/m3e_split_button_decoration.dart';
 export 'styles/m3e_split_button_theme.dart';


### PR DESCRIPTION
## Summary
Exports missing enums and models required by component constructors across buttons, FABs, split buttons, navigation rail, and navigation bar.

## Changes
- `lib/components/buttons/m3e_buttons.dart`: Export `enums/m3e_button_enums.dart` (`M3EButtonStyle`, `M3EButtonSize`, `M3EButtonShape`)
- `lib/components/floating_action_buttons/m3e_floating_action_buttons.dart`: Export `enums/m3e_fab.dart` (`M3EFabColor`, `M3EFabSize`)
- `lib/components/split_buttons/m3e_split_buttons.dart`: Export split button enums
- `lib/components/navigation_rail/m3e_navigation_rail.dart`: Export navigation rail enums and models
- `lib/components/navigation_bar/m3e_navigation_bar.dart`: Export navigation bar enums and models

Closes #13