### PR TITLE
fix: prevent dropdown onSelectionChange during build phase & export M3EButtonGroupAction

### DIFF
--- a/lib/components/dropdown_menus/controllers/m3e_dropdown_controller.dart
+++ b/lib/components/dropdown_menus/controllers/m3e_dropdown_controller.dart
@@ -141,14 +141,16 @@ class M3EDropdownController<T> extends ChangeNotifier {
   // ── Item management ──
 
   /// Replaces the entire item list, resetting the search query.
-  void setItems(List<M3EDropdownItem<T>> items) {
+  void setItems(List<M3EDropdownItem<T>> items, {bool notifySelection = false}) {
     _items
       ..clear()
       ..addAll(items);
     _searchQuery = '';
     _filteredItems = List.from(_items);
     notifyListeners();
-    onSelectionChange?.call(selectedItems);
+    if (notifySelection) {
+      onSelectionChange?.call(selectedItems);
+    }
   }
 
   /// Adds a single item. If [index] is provided, inserts at that position.

--- a/lib/components/toggle_button_group/m3e_toggle_button_group.dart
+++ b/lib/components/toggle_button_group/m3e_toggle_button_group.dart
@@ -27,6 +27,7 @@ import 'models/m3e_button_group_overflow_paging_window.dart';
 
 export 'components/m3e_toggle_button_group_scope.dart';
 export 'enums/m3e_toggle_button_group_enums.dart';
+export 'models/m3e_button_group_action.dart';
 export 'styles/m3e_toggle_button_group_theme.dart';
 
 part 'components/m3e_button_group_align.dart';

--- a/test/dropdown_menu_test.dart
+++ b/test/dropdown_menu_test.dart
@@ -22,6 +22,11 @@ Widget _host(Widget child) {
 
 void main() {
   testWidgets(
+    'M3EDropdownMenu widget rebuild does not fire onSelectionChanged during build phase',
+    _m3edropdownmenuRebuildDoesNotFireOnSelectionChangedDuringBuild,
+  );
+
+  testWidgets(
     'M3EDropdownMenu renders field with hint text',
     _m3edropdownmenuRendersFieldWithHintText,
   );
@@ -120,4 +125,51 @@ Future<void> _m3edropdownmenuSingleSelectReplacesPriorSelection(
 
   expect(selected, hasLength(1));
   expect(selected.first.value, 'm3');
+}
+
+Future<void> _m3edropdownmenuRebuildDoesNotFireOnSelectionChangedDuringBuild(
+  WidgetTester tester,
+) async {
+  int selectionCallCount = 0;
+  List<M3EDropdownItem<String>> currentItems = _items;
+
+  await tester.pumpWidget(
+    StatefulBuilder(
+      builder: (context, setState) {
+        return _host(
+          Column(
+            children: [
+              M3EDropdownMenu<String>(
+                items: currentItems,
+                onSelectionChanged: (_) {
+                  selectionCallCount++;
+                  setState(() {});
+                },
+              ),
+              ElevatedButton(
+                onPressed: () {
+                  setState(() {
+                    currentItems = const [
+                      M3EDropdownItem(label: 'Item A', value: 'a'),
+                      M3EDropdownItem(label: 'Item B', value: 'b'),
+                    ];
+                  });
+                },
+                child: const Text('Update Items'),
+              ),
+            ],
+          ),
+        );
+      },
+    ),
+  );
+
+  expect(selectionCallCount, 0);
+
+  // Trigger parent rebuild with updated items -> runs didUpdateWidget
+  await tester.tap(find.text('Update Items'));
+  await tester.pump();
+
+  expect(tester.takeException(), isNull);
+  expect(selectionCallCount, 0);
 }


### PR DESCRIPTION
### Summary of Changes

1. **Dropdown Lifecycle Safety**:
   - Fixed an issue where `_syncItemsFromWidget` called `_controller.setItems()` during `didUpdateWidget`, which unconditionally and synchronously triggered `onSelectionChange` while the framework was actively building.
   - Added `{bool notifySelection = false}` to `M3EDropdownController.setItems()`, ensuring widget lifecycle updates do not throw `setState() or markNeedsBuild() called during build`.
   - Added automated widget tests in `test/dropdown_menu_test.dart` to verify that parent rebuilds do not trigger unexpected selection callbacks.

2. **Missing Export**:
   - Exported `M3EButtonGroupAction` in `m3e_toggle_button_group.dart` so consumers can directly construct button group actions without private/missing symbol errors.

---

### Linked Issue

Closes #15

---

### Verification

Ran `flutter test` across all component tests:

```text
00:00 +0: M3EDropdownMenu widget rebuild does not fire onSelectionChanged during build phase
00:00 +1: M3EDropdownMenu renders field with hint text
00:00 +2: M3EDropdownMenu opens overlay and reports selection
00:00 +3: M3EDropdownMenu single select replaces prior selection
00:00 +4: All tests passed!
