### PR TITLE
Support custom NavigationRail toggle tooltips

### DIFF
--- a/lib/components/navigation_rail/m3e_navigation_rail.dart
+++ b/lib/components/navigation_rail/m3e_navigation_rail.dart
@@ -42,6 +42,8 @@ class M3ENavigationRail extends StatefulWidget {
     this.trailing,
     this.trailingAtBottom = true,
     this.background,
+    this.expandTooltip = 'Expand',
+    this.collapseTooltip = 'Collapse',
   });
 
   /// type.
@@ -89,6 +91,12 @@ class M3ENavigationRail extends StatefulWidget {
 
   /// background.
   final Color? background;
+
+  /// Tooltip shown for the button that expands the rail.
+  final String expandTooltip;
+
+  /// Tooltip shown for the button that collapses the rail.
+  final String collapseTooltip;
 
   @override
   State<M3ENavigationRail> createState() => _M3ENavigationRailState();
@@ -357,7 +365,7 @@ class _M3ENavigationRailState extends State<M3ENavigationRail>
     final isExpanded = _isExpanded;
     final Widget button = M3EIconButton(
       icon: Icon(isExpanded ? M3EIcons.menu_open : M3EIcons.menu),
-      tooltip: isExpanded ? 'Collapse' : 'Expand',
+      tooltip: isExpanded ? widget.collapseTooltip : widget.expandTooltip,
       onPressed: () => _setExpanded(!isExpanded),
       suppressInk: _suppressInk,
     );

--- a/test/navigation_and_inputs_test.dart
+++ b/test/navigation_and_inputs_test.dart
@@ -23,6 +23,10 @@ void main() {
     _m3enavigationrailRendersSectionDestinations,
   );
   testWidgets(
+    'M3ENavigationRail supports custom expand and collapse tooltips',
+    _m3enavigationrailSupportsCustomExpandAndCollapseTooltips,
+  );
+  testWidgets(
     'M3ENavigationRail resting indicator tracks selection while scrolling',
     _m3enavigationrailRestingIndicatorTracksSelectionWhileS,
   );
@@ -162,6 +166,44 @@ Future<void> _m3enavigationrailRendersSectionDestinations(
 
   expect(find.text('Inbox'), findsWidgets);
   expect(find.byIcon(M3EIcons.inbox), findsOneWidget);
+}
+
+Future<void> _m3enavigationrailSupportsCustomExpandAndCollapseTooltips(
+  WidgetTester tester,
+) async {
+  Widget buildRail(M3ENavigationRailType type, Key key) => M3ENavigationRail(
+    key: key,
+    type: type,
+    expandTooltip: '展开',
+    collapseTooltip: '折叠',
+    selectedIndex: 0,
+    onDestinationSelected: (_) {},
+    sections: const <M3ENavigationRailSection>[
+      M3ENavigationRailSection(
+        destinations: <M3ENavigationRailDestination>[
+          M3ENavigationRailDestination(
+            icon: Icon(M3EIcons.inbox),
+            label: 'Inbox',
+          ),
+        ],
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(
+    _host(
+      buildRail(M3ENavigationRailType.collapsed, const ValueKey('collapsed')),
+    ),
+  );
+  expect(find.byTooltip('展开'), findsOneWidget);
+
+  await tester.pumpWidget(
+    _host(
+      buildRail(M3ENavigationRailType.expanded, const ValueKey('expanded')),
+    ),
+  );
+  await tester.pump();
+  expect(find.byTooltip('折叠'), findsOneWidget);
 }
 
 Future<void> _m3enavigationrailRestingIndicatorTracksSelectionWhileS(


### PR DESCRIPTION
## Summary
- Add configurable `expandTooltip` and `collapseTooltip` properties to `M3ENavigationRail`.
- Preserve the existing English labels as defaults for backward compatibility.
- Use the configured labels for the rail toggle button.

## Tests
- Added widget coverage for custom tooltips in collapsed and expanded states.
- `flutter test test/navigation_and_inputs_test.dart --plain-name "M3ENavigationRail supports custom expand and collapse tooltips"`
- `dart analyze lib/components/navigation_rail/m3e_navigation_rail.dart test/navigation_and_inputs_test.dart`