### PR TITLE
Support custom FAB elevations

### DIFF
--- a/lib/components/extended_fabs/m3e_extended_fabs.dart
+++ b/lib/components/extended_fabs/m3e_extended_fabs.dart
@@ -20,10 +20,16 @@ class M3EExtendedFab extends StatelessWidget {
     this.color = M3EFabColor.primary,
     this.extended = true,
     this.decoration,
+    this.elevation,
+    this.hoverElevation,
     this.focusNode,
     this.autofocus = false,
     super.key,
-  });
+  }) : assert(elevation == null || elevation >= 0.0, 'assertion failed'),
+       assert(
+         hoverElevation == null || hoverElevation >= 0.0,
+         'assertion failed',
+       );
 
   /// label.
 
@@ -43,6 +49,16 @@ class M3EExtendedFab extends StatelessWidget {
 
   /// Optional decoration for solid and gradient surfaces.
   final M3EFabDecoration? decoration;
+
+  /// Resting surface elevation.
+  ///
+  /// Defaults to the themed extended FAB elevation.
+  final double? elevation;
+
+  /// Surface elevation while hovered.
+  ///
+  /// Defaults to the themed extended FAB hover elevation.
+  final double? hoverElevation;
 
   /// focusNode.
 
@@ -110,7 +126,9 @@ class M3EExtendedFab extends StatelessWidget {
     final BorderSide? side = outline != null
         ? null
         : decoration?.side?.resolve(states);
-    final elevation = extendedTheme.elevation(hovered: state.hovered);
+    final resolvedElevation = state.hovered
+        ? hoverElevation ?? extendedTheme.elevation(hovered: true)
+        : elevation ?? extendedTheme.elevation(hovered: false);
 
     Widget content = _decorateContent(
       state: state,
@@ -138,7 +156,7 @@ class M3EExtendedFab extends StatelessWidget {
         borderRadius: borderRadius,
         border: side == null ? null : Border.fromBorderSide(side),
         boxShadow: M3EElevation.shadows(
-          elevation,
+          resolvedElevation,
           shadowColor: theme.colorScheme.shadow,
         ),
       ),

--- a/lib/components/floating_action_buttons/m3e_floating_action_buttons.dart
+++ b/lib/components/floating_action_buttons/m3e_floating_action_buttons.dart
@@ -23,11 +23,17 @@ class M3EFab extends StatelessWidget {
     this.color = M3EFabColor.primary,
     this.cornerRadius,
     this.decoration,
+    this.elevation,
+    this.hoverElevation,
     this.tooltip,
     this.focusNode,
     this.autofocus = false,
     super.key,
-  });
+  }) : assert(elevation == null || elevation >= 0.0, 'assertion failed'),
+       assert(
+         hoverElevation == null || hoverElevation >= 0.0,
+         'assertion failed',
+       );
 
   /// icon.
 
@@ -47,6 +53,16 @@ class M3EFab extends StatelessWidget {
 
   /// Optional decoration for solid and gradient surfaces.
   final M3EFabDecoration? decoration;
+
+  /// Resting surface elevation.
+  ///
+  /// Defaults to [M3EElevation.level3].
+  final double? elevation;
+
+  /// Surface elevation while hovered.
+  ///
+  /// Defaults to [M3EElevation.level4].
+  final double? hoverElevation;
 
   /// tooltip.
   final String? tooltip;
@@ -118,7 +134,9 @@ class M3EFab extends StatelessWidget {
     final BorderSide? side = outline != null
         ? null
         : decoration?.side?.resolve(states);
-    final elevation = state.hovered ? M3EElevation.level4 : M3EElevation.level3;
+    final resolvedElevation = state.hovered
+        ? hoverElevation ?? M3EElevation.level4
+        : elevation ?? M3EElevation.level3;
 
     Widget content = _decorateContent(
       state: state,
@@ -149,7 +167,7 @@ class M3EFab extends StatelessWidget {
         borderRadius: borderRadius,
         border: side == null ? null : Border.fromBorderSide(side),
         boxShadow: M3EElevation.shadows(
-          elevation,
+          resolvedElevation,
           shadowColor: theme.colorScheme.shadow,
         ),
       ),

--- a/lib/components/navigation_rail/m3e_navigation_rail.dart
+++ b/lib/components/navigation_rail/m3e_navigation_rail.dart
@@ -383,6 +383,8 @@ class _M3ENavigationRailState extends State<M3ENavigationRail>
               icon: fab.icon,
               onPressed: fab.onPressed,
               color: fab.color,
+              elevation: fab.elevation,
+              hoverElevation: fab.hoverElevation,
             )
           : M3EFab(
               icon: fab.icon,
@@ -390,6 +392,8 @@ class _M3ENavigationRailState extends State<M3ENavigationRail>
               tooltip: fab.tooltip,
               color: fab.color,
               size: fab.size,
+              elevation: fab.elevation,
+              hoverElevation: fab.hoverElevation,
             ),
     );
   }

--- a/lib/components/navigation_rail/models/m3e_navigation_rail_fab_slot.dart
+++ b/lib/components/navigation_rail/models/m3e_navigation_rail_fab_slot.dart
@@ -19,8 +19,14 @@ class M3ENavigationRailFabSlot {
     this.tooltip,
     this.color = M3EFabColor.primary,
     this.size = M3EFabSize.medium,
+    this.elevation,
+    this.hoverElevation,
     this.semanticLabel,
-  });
+  }) : assert(elevation == null || elevation >= 0.0, 'assertion failed'),
+       assert(
+         hoverElevation == null || hoverElevation >= 0.0,
+         'assertion failed',
+       );
 
   /// Icon widget shown inside the FAB (collapsed) and leading icon (expanded).
   final Widget icon;
@@ -39,6 +45,12 @@ class M3ENavigationRailFabSlot {
 
   /// Size of the FAB button.
   final M3EFabSize size;
+
+  /// Resting surface elevation for the rail FAB.
+  final double? elevation;
+
+  /// Surface elevation for the rail FAB while hovered.
+  final double? hoverElevation;
 
   /// Optional semantic label for accessibility.
   final String? semanticLabel;

--- a/test/navigation_and_inputs_test.dart
+++ b/test/navigation_and_inputs_test.dart
@@ -23,6 +23,10 @@ void main() {
     _m3enavigationrailRendersSectionDestinations,
   );
   testWidgets(
+    'M3ENavigationRail FAB slot supports custom elevation',
+    _m3enavigationrailFabSlotSupportsCustomElevation,
+  );
+  testWidgets(
     'M3ENavigationRail resting indicator tracks selection while scrolling',
     _m3enavigationrailRestingIndicatorTracksSelectionWhileS,
   );
@@ -162,6 +166,48 @@ Future<void> _m3enavigationrailRendersSectionDestinations(
 
   expect(find.text('Inbox'), findsWidgets);
   expect(find.byIcon(M3EIcons.inbox), findsOneWidget);
+}
+
+Future<void> _m3enavigationrailFabSlotSupportsCustomElevation(
+  WidgetTester tester,
+) async {
+  await tester.pumpWidget(
+    _host(
+      M3ENavigationRail(
+        type: M3ENavigationRailType.collapsed,
+        selectedIndex: 0,
+        onDestinationSelected: (_) {},
+        fab: const M3ENavigationRailFabSlot(
+          icon: Icon(M3EIcons.add),
+          label: 'Create',
+          elevation: 0,
+          hoverElevation: 0,
+        ),
+        sections: const <M3ENavigationRailSection>[
+          M3ENavigationRailSection(
+            destinations: <M3ENavigationRailDestination>[
+              M3ENavigationRailDestination(
+                icon: Icon(M3EIcons.inbox),
+                label: 'Inbox',
+              ),
+            ],
+          ),
+        ],
+      ),
+    ),
+  );
+  await tester.pump();
+
+  final fabContainer = tester.widget<AnimatedContainer>(
+    find.descendant(
+      of: find.byType(M3EFab),
+      matching: find.byType(AnimatedContainer),
+    ),
+  );
+  final decoration = fabContainer.decoration;
+
+  expect(decoration, isA<BoxDecoration>());
+  expect((decoration! as BoxDecoration).boxShadow, isEmpty);
 }
 
 Future<void> _m3enavigationrailRestingIndicatorTracksSelectionWhileS(


### PR DESCRIPTION
## Summary
- add optional resting and hover elevation overrides to M3EFab and M3EExtendedFab
- pass elevation overrides through M3ENavigationRailFabSlot
- add widget test coverage for a flat NavigationRail FAB

## Tests
- dart analyze lib/components/floating_action_buttons/m3e_floating_action_buttons.dart lib/components/extended_fabs/m3e_extended_fabs.dart lib/components/navigation_rail/models/m3e_navigation_rail_fab_slot.dart lib/components/navigation_rail/m3e_navigation_rail.dart test/navigation_and_inputs_test.dart
- flutter test test/navigation_and_inputs_test.dart --plain-name 'M3ENavigationRail FAB slot supports custom elevation'